### PR TITLE
Added fontSize prop to handle dynamic  font size changes to the markdown content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-translatable",
-  "version": "1.2.15-rc5",
+  "version": "1.2.15-rc6",
   "license": "MIT",
   "description": "A Collection of Components for Translating Markdown Files.",
   "homepage": "https://markdown-translatable.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-translatable",
-  "version": "1.2.15-rc1",
+  "version": "1.2.15-rc2",
   "license": "MIT",
   "description": "A Collection of Components for Translating Markdown Files.",
   "homepage": "https://markdown-translatable.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-translatable",
-  "version": "1.2.15-rc4",
+  "version": "1.2.15-rc5",
   "license": "MIT",
   "description": "A Collection of Components for Translating Markdown Files.",
   "homepage": "https://markdown-translatable.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-translatable",
-  "version": "1.2.14",
+  "version": "1.2.15-rc1",
   "license": "MIT",
   "description": "A Collection of Components for Translating Markdown Files.",
   "homepage": "https://markdown-translatable.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-translatable",
-  "version": "1.2.15-rc6",
+  "version": "1.2.15-rc7",
   "license": "MIT",
   "description": "A Collection of Components for Translating Markdown Files.",
   "homepage": "https://markdown-translatable.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-translatable",
-  "version": "1.2.15-rc2",
+  "version": "1.2.15-rc3",
   "license": "MIT",
   "description": "A Collection of Components for Translating Markdown Files.",
   "homepage": "https://markdown-translatable.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-translatable",
-  "version": "1.2.15-rc3",
+  "version": "1.2.15-rc4",
   "license": "MIT",
   "description": "A Collection of Components for Translating Markdown Files.",
   "homepage": "https://markdown-translatable.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-translatable",
-  "version": "1.2.15-rc7",
+  "version": "1.2.15-rc8",
   "license": "MIT",
   "description": "A Collection of Components for Translating Markdown Files.",
   "homepage": "https://markdown-translatable.netlify.com/",

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -25,11 +25,11 @@ function BlockEditable({
   editable,
   fontSize,
 }) {
+  const classes = useStyles();
+  const { actions } = useContext(MarkdownContext);
   const _oldMarkdown = { markdown };
 
-  const { actions } = useContext(MarkdownContext);
-
-  const classes = useStyles({ fontSize });
+  console.log({ fontSize });
 
   const _style = useMemo(
     () =>
@@ -95,7 +95,7 @@ function BlockEditable({
         <pre className={classes.pre}>
           <code
             className={classes.markdown}
-            style={_style}
+            style={{ ..._style, fontSize }}
             dir='auto'
             contentEditable={editable}
             dangerouslySetInnerHTML={dangerouslySetInnerHTML}
@@ -109,7 +109,7 @@ function BlockEditable({
 
       _component = (
         <div
-          style={_style}
+          style={{ ..._style, fontSize }}
           className={classes.html}
           dir='auto'
           contentEditable={editable}
@@ -120,7 +120,7 @@ function BlockEditable({
       );
     }
     return _component;
-  }, [preview, markdown, inputFilters, classes.pre, classes.markdown, classes.html, _style, editable, handleRawBlur, handleKeyDown, handleHTMLBlur]);
+  }, [fontSize, preview, markdown, inputFilters, classes.pre, classes.markdown, classes.html, _style, editable, handleRawBlur, handleKeyDown, handleHTMLBlur]);
 
   return <div className={classes.root}>{component}</div>;
 }

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -118,7 +118,7 @@ function BlockEditable({
       );
     }
     return _component;
-  }, [fontSize, preview, markdown]);
+  }, [fontSize, preview, markdown, editable]);
 
   return <div className={classes.root}>{component}</div>;
 }

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -118,7 +118,7 @@ function BlockEditable({
       );
     }
     return _component;
-  }, [fontSize, preview, markdown, inputFilters, classes.pre, classes.markdown, classes.html, _style, editable, handleRawBlur, handleKeyDown, handleHTMLBlur]);
+  }, [fontSize, preview, markdown, inputFilters]);
 
   return <div className={classes.root}>{component}</div>;
 }

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -120,7 +120,7 @@ function BlockEditable({
       );
     }
     return _component;
-  }, [preview, markdown, editable]);
+  }, [preview, markdown, inputFilters, classes.pre, classes.markdown, classes.html, _style, editable, handleRawBlur, handleKeyDown, handleHTMLBlur]);
 
   return <div className={classes.root}>{component}</div>;
 }

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -118,7 +118,7 @@ function BlockEditable({
       );
     }
     return _component;
-  }, [fontSize, preview, markdown, inputFilters]);
+  }, [fontSize, preview, markdown]);
 
   return <div className={classes.root}>{component}</div>;
 }

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -29,8 +29,6 @@ function BlockEditable({
   const { actions } = useContext(MarkdownContext);
   const _oldMarkdown = { markdown };
 
-  console.log({ fontSize });
-
   const _style = useMemo(
     () =>
       helpers.isHebrew(markdown) ? { ...style, fontSize: '1.5em' } : style,

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -138,7 +138,7 @@ BlockEditable.propTypes = {
   preview: PropTypes.bool,
   /** Enable/Disable editability. */
   editable: PropTypes.bool,
-  /** fontSize for Markdown class, e.g. '100%' */
+  /** fontSize e.g. '100%' */
   fontSize: PropTypes.string,
 };
 

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -119,7 +119,7 @@ function BlockEditable({
       );
     }
     return _component;
-  }, [preview, markdown, inputFilters, classes.pre, classes.markdown, classes.html, _style, editable, handleRawBlur, handleKeyDown, handleHTMLBlur]);
+  }, [preview, markdown]);
 
   return <div className={classes.root}>{component}</div>;
 }

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -119,7 +119,7 @@ function BlockEditable({
       );
     }
     return _component;
-  }, [preview, markdown]);
+  }, [preview, markdown, editable]);
 
   return <div className={classes.root}>{component}</div>;
 }

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -1,4 +1,6 @@
-import React, { useMemo, useCallback, useContext } from 'react';
+import React, {
+  useMemo, useCallback, useContext,
+} from 'react';
 import PropTypes from 'prop-types';
 
 import * as helpers from '../../core/';
@@ -9,9 +11,9 @@ import {
   fromDisplay,
   toDisplay,
 } from '../../core/';
+import { MarkdownContext } from '../Markdown.context';
 import { useStyles } from './useStyles';
 
-import { MarkdownContext } from '../Markdown.context'
 
 function BlockEditable({
   markdown,
@@ -50,7 +52,7 @@ function BlockEditable({
         onEdit(_markdown);
       }
     },
-    [markdown, inputFilters, onEdit]
+    [_oldMarkdown.markdown, inputFilters, onEdit]
   );
 
   const handleHTMLBlur = useCallback(
@@ -102,9 +104,7 @@ function BlockEditable({
         </pre>
       );
     } else {
-      const dangerouslySetInnerHTML = {
-        __html: markdownToHtml({ markdown, inputFilters }),
-      };
+      const dangerouslySetInnerHTML = { __html: markdownToHtml({ markdown, inputFilters }) };
 
       _component = (
         <div
@@ -119,7 +119,7 @@ function BlockEditable({
       );
     }
     return _component;
-  }, [preview, markdown, editable]);
+  }, [preview, markdown, inputFilters, classes.pre, classes.markdown, classes.html, _style, editable, handleRawBlur, handleKeyDown, handleHTMLBlur]);
 
   return <div className={classes.root}>{component}</div>;
 }
@@ -139,6 +139,8 @@ BlockEditable.propTypes = {
   preview: PropTypes.bool,
   /** Enable/Disable editability. */
   editable: PropTypes.bool,
+  /** fontSize for Markdown class, e.g. '100%' */
+  fontSize: PropTypes.string,
 };
 
 BlockEditable.defaultProps = {

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -23,12 +23,13 @@ function BlockEditable({
   style,
   preview,
   editable,
+  fontSize,
 }) {
   const _oldMarkdown = { markdown };
 
   const { actions } = useContext(MarkdownContext);
 
-  const classes = useStyles();
+  const classes = useStyles({ fontSize });
 
   const _style = useMemo(
     () =>

--- a/src/components/block-editable/README.md
+++ b/src/components/block-editable/README.md
@@ -25,7 +25,7 @@ initialState = {
       console.log('Setting new state: ' + _markdown);
       setState({ _markdown });
     }}
-    fontSize="200%"
+    fontSize="100%"
   />
 </div>;
 ```

--- a/src/components/block-editable/README.md
+++ b/src/components/block-editable/README.md
@@ -25,6 +25,7 @@ initialState = {
       console.log('Setting new state: ' + _markdown);
       setState({ _markdown });
     }}
+    fontSize="200%"
   />
 </div>;
 ```

--- a/src/components/block-editable/useStyles.js
+++ b/src/components/block-editable/useStyles.js
@@ -22,7 +22,7 @@ export const useStyles = makeStyles(theme => ({
     fontFamily: 'unset',
     padding: '0 0.5em',
     lineHeight: '1.4',
-    fontSize: ({ fontSize }) => (fontSize || 'unset'),
+    fontSize: 'unset',
   },
   pre: {
     margin: 0,

--- a/src/components/block-editable/useStyles.js
+++ b/src/components/block-editable/useStyles.js
@@ -15,15 +15,14 @@ export const useStyles = makeStyles(theme => ({
   markdown: {
     height: '100%',
     width: 'calc(100% - 1em)',
-    // fontSize: '1.1em',
     display: 'grid',
     whiteSpace: 'pre-wrap',
     paddingBlockStart: '1em',
     paddingBlockEnd: '1em',
-    fontSize: 'unset',
     fontFamily: 'unset',
     padding: '0 0.5em',
     lineHeight: '1.4',
+    fontSize: ({ fontSize }) => (fontSize || 'unset'),
   },
   pre: {
     margin: 0,


### PR DESCRIPTION
# Test Instructions

- [ ] Open https://deploy-preview-57--markdown-translatable.netlify.app/#/Block%20Editable?id=blockeditable
- [ ] Scroll down to `VIEW CODE`
- [ ] Change the fontSize prop and it should change the text size above.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/markdown-translatable/57)
<!-- Reviewable:end -->
