### PR TITLE
Turn off editing in preview mode.

### DIFF
--- a/src/components/actions/Actions.js
+++ b/src/components/actions/Actions.js
@@ -35,7 +35,7 @@ function Actions({
   const toggleBlockable = useCallback(() => _onBlockable(!blockable), [blockable, _onBlockable]);
 
   const saveIcon = useMemo(() => (changed ? <Save /> : <SaveOutlined />), [changed]);
-  const previewIcon = useMemo(() => (!preview ? <Pageview /> : <PageviewOutlined />), [preview]);
+  const previewIcon = useMemo(() => (preview ? <Pageview /> : <PageviewOutlined />), [preview]);
   const sectionableIcon = useMemo(() => (sectionable ? <ViewStream /> : <ViewStreamOutlined /> ), [sectionable]);
   const blockableIcon = useMemo(() => (blockable ? <ShortText /> : <Subject />), [blockable]);
 

--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -113,7 +113,6 @@ export default function BlockEditable({
             style={{ ..._style, fontSize }}
             className={classes.html}
             dir='auto'
-            contentEditable={editable}
             onBlur={handleHTMLBlur}
             onKeyPress={handleKeyPress}
             onKeyUp={handleKeyUp}

--- a/src/components/translatable/Translatable.js
+++ b/src/components/translatable/Translatable.js
@@ -27,7 +27,7 @@ function Translatable({
   onContentIsDirty,
 }) {
   const classes = useStyles();
-  const [preview, setPreview] = useState(true);
+  const [preview, setPreview] = useState(false);
   const [sectionable, setSectionable] = useState(true);
   const [blockable, setBlockable] = useState(true);
   const [editedTranslation, setEditedTranslation] = useState(translation);


### PR DESCRIPTION
Also default to preview mode disabled.

Closes https://github.com/unfoldingWord/tc-create-app/issues/1128
Closes https://github.com/unfoldingWord/tc-create-app/issues/1127
Probably also closes https://github.com/unfoldingWord/tc-create-app/issues/1155

Changes should be easy to test in styleguidist. 
* Load start page
* All fields should be showing markdown and be editable.
* Click Preview button
* Fields should render as HTML and **not** be editable.

### To be determined:

* If gateway-edit wants the same behavior.
  * Since this RCL is used by tc-create and gateway-edit this change will affect both apps
* If we should strip out some code related to converting from HTML to markdown. 
  * Since we are no longer allowing edits in preview mode I believe there will be some dead code that should be removed. Probably leave this for future technical debt.
