### PR TITLE
Do not prevent cut event

### DIFF
--- a/src/components/block-editable/BlockEditable.js
+++ b/src/components/block-editable/BlockEditable.js
@@ -80,9 +80,12 @@ export default function BlockEditable({
   };
 
   const handleCutPaste = (event) => {
-    const pastedData = event.clipboardData.getData('text/plain');
-    event.preventDefault();
-    document.execCommand("insertText", false, pastedData);
+    if ( 'paste' === event.type) {
+      const pastedData = event.clipboardData.getData('text/plain');
+      event.preventDefault();
+      document.execCommand("insertText", false, pastedData);
+    }
+
     if (actions && actions.setIsChanged) {
       actions.setIsChanged(true);
     }


### PR DESCRIPTION
Fixes https://github.com/unfoldingWord/tc-create-app/issues/1292

Since this method is triggered onCut and onPaste we don't want to prevent default when it is the cut event.
